### PR TITLE
Bugfix/transient reference cache

### DIFF
--- a/packages/ember-model/lib/model.js
+++ b/packages/ember-model/lib/model.js
@@ -889,12 +889,14 @@ Ember.Model.reopenClass({
   },
 
   _cacheReference: function(reference) {
-    if (!this._referenceCache) { this._referenceCache = {}; }
+   if (!this.transient) {
+      if (!this._referenceCache) { this._referenceCache = {}; }
 
-    // if we're creating an item, this process will be done
-    // later, once the object has been persisted.
-    if (!Ember.isEmpty(reference.id)) {
-      this._referenceCache[reference.id] = reference;
+      // if we're creating an item, this process will be done
+      // later, once the object has been persisted.
+      if (!Ember.isEmpty(reference.id)) {
+        this._referenceCache[reference.id] = reference;
+      }
     }
   }
 });

--- a/packages/ember-model/tests/model_test.js
+++ b/packages/ember-model/tests/model_test.js
@@ -762,6 +762,44 @@ test("record is available in reference cache when load is run in cachedRecordFor
   ok(recordFromCache, 'record should be available in cache when running load');
 });
 
+test("reference cache is undefined from record when Model.transient is true in _createReference", function() {
+  var id = 1;
+  var recordFromCache,
+      Post = Ember.Model.extend({
+        id: id,
+        load: function() {
+          recordFromCache = this.constructor._referenceCache['1'].record;
+        }
+      });
+
+  Post.reopenClass({
+    transient: true
+  });
+
+  Post._createReference(1);
+
+  equal(Post._referenceCache[id], undefined, 'referenceCache at id is undefined when transient is true');
+});
+
+test("reference cache is available from record when Model.transient is false in _createReference", function() {
+  var id = 1;
+  var recordFromCache,
+      Post = Ember.Model.extend({
+        id: id,
+        load: function() {
+          recordFromCache = this.constructor._referenceCache['1'].record;
+        }
+      });
+
+  Post.reopenClass({
+    transient: false
+  });
+
+  Post._createReference(1);
+
+  equal(Post._referenceCache[id].id, 1, 'referenceCache has an id of 1 when transient is false');
+});
+
 test("fetchQuery returns a promise", function() {
   expect(1);
 


### PR DESCRIPTION
JIRA: [COPILOT-4355](https://cnissues.atlassian.net/browse/COPILOT-4355)
Related PRs: https://github.com/CondeNast/copilot/pull/2933
- Fixes this particular variant issue in copilot: 
  - A content's `Tout` has main photo `foo` with a variant photo `bar`
  - The same content's `Lede` has a main photo `bar` with a variant `foo`
  - When saving the content with the above, refreshing the page results in the `Tout`'s main photo variants to not load (the data on the API side still has these variants).
  - This occurs because ember-model cached `foo`'s object from when it loaded the `Lede`'s `foo` variant
  - The `foo` variant (from `Lede`'s `bar`) at this point doesn't have `variants` loaded so the cached version doesn't have it either.
- The fix: when `_cacheReference` is called from `_createReference`, perform a check for `!this.transient` so that it will not set a `_referenceCache`